### PR TITLE
Top5Reach update

### DIFF
--- a/Diversity/WebContent/tests/target/classes/META-INF/MANIFEST.MF
+++ b/Diversity/WebContent/tests/target/classes/META-INF/MANIFEST.MF
@@ -1,5 +1,5 @@
 Manifest-Version: 1.0
-Built-By: Fￃﾡbio Mano
-Build-Jdk: 1.8.0_111
+Built-By: francsicosilva
+Build-Jdk: 1.8.0_101
 Created-By: Maven Integration for Eclipse
 

--- a/Diversity/src/extraction/GetReach.java
+++ b/Diversity/src/extraction/GetReach.java
@@ -7,7 +7,10 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.GregorianCalendar;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -17,6 +20,9 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 import com.mysql.fabric.xmlrpc.base.Value;
+import com.sun.jna.platform.win32.Advapi32Util.Account;
+import com.sun.jndi.toolkit.ctx.Continuation;
+import com.sun.org.apache.xpath.internal.operations.Mod;
 
 import general.Data;
 import general.Logging;
@@ -33,6 +39,34 @@ public class GetReach {
 	private static final Logger LOGGER = new Logging().create(GetReach.class.getName());
 	private String[] time = { "JAN", "FEB", "MAR", "APR", "MAY", "JUN", "JUL", "AUG", "SEP", "OCT", "NOV", "DEC" };
 
+	class PssSA {
+		ArrayList<String> accounts = new ArrayList<>();
+		ArrayList<String> sources = new ArrayList<>();
+		int avgReach;
+
+		void addSourceAccount(String source, String account) {
+			accounts.add(account);
+			sources.add(source);
+		}
+
+		public void setAvgReach(int avgReach) {
+			this.avgReach = avgReach;
+		}
+
+		public ArrayList<String> getAccounts() {
+			return accounts;
+		}
+
+		public int getAvgReach() {
+			return avgReach;
+		}
+
+		public ArrayList<String> getSources() {
+			return sources;
+		}
+
+	}
+
 	/**
 	 * Returns an array list with the nTOP number of pss's with higher reach on the
 	 * of the last 12 months.
@@ -41,23 +75,78 @@ public class GetReach {
 	 *            - Number of PSS wanted
 	 * @return ArrayList of pss id's
 	 */
+
 	public List<Long> getTOPReach(int nTOP) {
 		ArrayList<Long> tops = new ArrayList<>();
+		HashMap<Long, PssSA> psss = new HashMap<>();
+		HashMap<Long, Float> avgReachByPss = new HashMap<>();
 
-		String select = "Select " + Settings.lotable_pss + " from " + Settings.lotable + " where "
-				+ Settings.lotable_pss + " in (Select distinct " + Settings.lmtable_pss + " from " + Settings.lmtable
-				+ " where " + Settings.lmtable_archived + "=0) group by " + Settings.lotable_pss + " order by AVG("
-				+ Settings.lotable_reach + ") desc limit " + nTOP;
+		for (Model mod : Data.getAllModels().values()) {
+			if (mod.getArchived())
+				continue;
+			String[] sourceAcounts = mod.getURI().split(";");
+			long pssId = mod.getPSS();
 
-		try (Connection cnlocal = Settings.connlocal();
-				PreparedStatement query1 = cnlocal.prepareStatement(select);
-				ResultSet rs = query1.executeQuery()) {
-			while (rs.next()) {
-				tops.add(rs.getLong(Settings.lotable_pss));
+			if (psss.containsKey(pssId)) {
+				for (String sourceAccount : sourceAcounts)
+					psss.get(pssId).addSourceAccount(sourceAccount.split(",")[0], sourceAccount.split(",")[1]);
+			} else {
+				PssSA p = new PssSA();
+				for (String sourceAccount : sourceAcounts)
+					p.addSourceAccount(sourceAccount.split(",")[0], sourceAccount.split(",")[1]);
+				psss.put(pssId, p);
 			}
-		} catch (Exception e) {
-			LOGGER.log(Level.SEVERE, "ERROR", e);
-			return new ArrayList<>();
+
+		}
+
+		psss.forEach((k, v) -> {
+			// String select = "Select avg(reach) from opinions where account in (";
+			// for (String account : v.getAccounts())
+			// select += "\"" + account + "\",";
+			// select = select.substring(0, select.length() - 1);
+			// select += ") and source in (";
+			// for (String source : v.getSources())
+			// select += "\"" + source + "\",";
+			// select = select.substring(0, select.length() - 1);
+			// select += ")";
+
+			String select = "Select avg(reach) from opinions where ";
+			for (int i = 0; i < v.getAccounts().size();i++) {
+				if(i==0)
+					select += "(account=\"" + v.getAccounts().get(i) + "\" AND source=\"" + v.getSources().get(i) + "\")";
+				else
+					select += " OR (account=\"" + v.getAccounts().get(i) + "\" AND source=\"" + v.getSources().get(i) + "\")";				
+			}
+				
+
+			try (Connection cnlocal = Settings.connlocal();
+					PreparedStatement query1 = cnlocal.prepareStatement(select);
+					ResultSet rs = query1.executeQuery()) {
+				while (rs.next()) {
+					avgReachByPss.put(k, rs.getFloat(1));
+					Logger.getLogger(GetReach.class.getName()).log(Level.INFO,
+							select + " PSS:" + k + "Average Reach: " + rs.getFloat("avg(reach)"));
+				}
+			} catch (Exception e) {
+				LOGGER.log(Level.SEVERE, "ERROR", e);
+			}
+
+		});
+
+		for (int i = 0; i < nTOP; i++) {
+			Map.Entry<Long, Float> maxEntry = null;
+
+			for (Map.Entry<Long, Float> entry : avgReachByPss.entrySet()) {
+				if (maxEntry == null || entry.getValue().compareTo(maxEntry.getValue()) > 0) {
+					maxEntry = entry;
+				}
+			}
+
+			if (avgReachByPss.isEmpty())
+				break;
+			Logger.getLogger(GetReach.class.getName()).log(Level.INFO, "Maxreach: " + maxEntry.getValue() + "\n");
+			tops.add(maxEntry.getKey());
+			avgReachByPss.remove(maxEntry.getKey());
 		}
 
 		return tops;
@@ -93,7 +182,7 @@ public class GetReach {
 
 		data.setTimeInMillis(firstDate(id));
 		data.add(Calendar.MONTH, 1);
-		today.add(Calendar.MONTH,1);
+		today.add(Calendar.MONTH, 1);
 
 		int avg = 0;
 		double last_value = 0;
@@ -134,18 +223,27 @@ public class GetReach {
 				+ Settings.lotable_reach + " FROM " + Settings.lptable + ", " + Settings.lotable + " WHERE "
 				+ Settings.lotable_timestamp + ">=? AND " + Settings.lotable + "." + Settings.lotable_id + "="
 				+ Settings.lptable + "." + Settings.lptable_opinion
-				+ " AND opinions.id in (Select opinions.id from opinions,authors where opinions.authors_id = authors.id AND timestamp>? && timestamp<=? ";/*and "*//*
-																										 * &&
-																										 * (" + Settings.lptable + "
-																										 * ." +
-																										 * Settings.
-																										 * lptable_authorid
-																										 * + "=" +
-																										 * Settings.
-																										 * latable + "."
-																										 * + Settings.
-																										 * latable_id;
-																										 */
+				+ " AND opinions.id in (Select opinions.id from opinions,authors where opinions.authors_id = authors.id AND timestamp>? && timestamp<=? ";/*
+																																							 * and
+																																							 * "
+																																							 *//*
+																																								 * &&
+																																								 * (" + Settings.lptable + "
+																																								 * ."
+																																								 * +
+																																								 * Settings.
+																																								 * lptable_authorid
+																																								 * +
+																																								 * "="
+																																								 * +
+																																								 * Settings.
+																																								 * latable
+																																								 * +
+																																								 * "."
+																																								 * +
+																																								 * Settings.
+																																								 * latable_id;
+																																								 */
 		return calc_global(false, "reach", insert, par, month, model, year, day, frequency);
 	}
 
@@ -160,38 +258,35 @@ public class GetReach {
 		 * null) insert += " AND " + Settings.latable + "." + Settings.latable_location
 		 * + "=?";
 		 */
-		
-		if (par.age != null) 
-			insert += " AND " + Settings.latable + "." + Settings.latable_age + "<=? AND " + 
-				 Settings.latable + "." + Settings.latable_age + ">?"; 
-		
-		if (par.gender != null) 
-			insert += " AND " + Settings.latable + "." + Settings.latable_gender + "=?"; 
-		
-		if (par.location !=	 null) 
+
+		if (par.age != null)
+			insert += " AND " + Settings.latable + "." + Settings.latable_age + "<=? AND " + Settings.latable + "."
+					+ Settings.latable_age + ">?";
+
+		if (par.gender != null)
+			insert += " AND " + Settings.latable + "." + Settings.latable_gender + "=?";
+
+		if (par.location != null)
 			insert += " AND " + Settings.latable + "." + Settings.latable_location + "=?";
-		
-		 /* if (!wiki) { if (par.products != null) { if (par.products.equals("-1")) {
+
+		/*
+		 * if (!wiki) { if (par.products != null) { if (par.products.equals("-1")) {
 		 * insert += " AND " + Settings.lotable_product + " in (" + model.getProducts()
 		 * + ")"; } else { insert += " AND " + Settings.lotable_product + "=?"; } } else
 		 * { if (!"polar".equals(type)) insert += " AND " + Settings.lotable_product +
 		 * " in (" + model.getProducts() + ")"; } } if (!model.getMediawiki()) insert +=
 		 * " AND " + Settings.lotable + "." + Settings.lotable_product + " is not null";
 		 */
-		
-		/*if (!wiki) { 
-			if (par.products != null) { 
-				if (par.products.equals("-1") && model.getProducts() != "") {
-					insert += " AND " + Settings.lotable_product + " in (" + model.getProducts() + ")"; 
-				} else { 
-					insert += " AND " + Settings.lotable_product + "=?"; 
-				} 
-			} else { 
-				//if (!"polar".equals(type) && model.getProducts() != "") 
-					//insert += " AND " + Settings.lotable_product + " in (" + model.getProducts() + ")"; 
-			} 
-		} */
-		
+
+		/*
+		 * if (!wiki) { if (par.products != null) { if (par.products.equals("-1") &&
+		 * model.getProducts() != "") { insert += " AND " + Settings.lotable_product +
+		 * " in (" + model.getProducts() + ")"; } else { insert += " AND " +
+		 * Settings.lotable_product + "=?"; } } else { //if (!"polar".equals(type) &&
+		 * model.getProducts() != "") //insert += " AND " + Settings.lotable_product +
+		 * " in (" + model.getProducts() + ")"; } }
+		 */
+
 		if (!model.getMediawiki()) {
 			insert += " AND " + Settings.lotable + "." + Settings.lotable_product + " is not null";
 		}
@@ -225,21 +320,23 @@ public class GetReach {
 
 			if (wiki || model.getId() == -1)
 				query1.setLong(rangeindex++, model.getPSS());
-			
-			if (par.age != null) { 
+
+			if (par.age != null) {
 				query1.setString(rangeindex++, par.age.split("-")[1]);
-				query1.setString(rangeindex++, par.age.split("-")[0]); 
-			} 
-			
-			if (par.gender != null) 
-				query1.setString(rangeindex++, par.gender); 
-			
+				query1.setString(rangeindex++, par.age.split("-")[0]);
+			}
+
+			if (par.gender != null)
+				query1.setString(rangeindex++, par.gender);
+
 			if (par.location != null)
-				query1.setString(rangeindex++, par.location); 
-			
-			/*if (par.products != null)
-				query1.setLong(rangeindex++, Long.valueOf(Data.identifyProduct(par.products)));*/
-			
+				query1.setString(rangeindex++, par.location);
+
+			/*
+			 * if (par.products != null) query1.setLong(rangeindex++,
+			 * Long.valueOf(Data.identifyProduct(par.products)));
+			 */
+
 			if (model.getId() != -1 && !wiki) {
 				ArrayList<String> sourceaccount = model.getSources(false);
 				for (int ii = 0; ii < sourceaccount.size(); ii++)
@@ -250,7 +347,7 @@ public class GetReach {
 			}
 
 			// LOGGER.log(Level.INFO," WIKI "+ wiki + " " +query1);
-//			System.out.println(query1.toString());
+			// System.out.println(query1.toString());
 			try (ResultSet rs = query1.executeQuery()) {
 				result = calc_avg(type, rs);
 
@@ -400,7 +497,7 @@ public class GetReach {
 	}
 
 	protected static parameters split_params(String param, String value) {
-		if (param == null|| value==null)
+		if (param == null || value == null)
 			return new parameters();
 		String[] params = param.split(",");
 		String[] values = value.split(",");

--- a/Diversity/src/general/Backend.java
+++ b/Diversity/src/general/Backend.java
@@ -513,34 +513,21 @@ public class Backend {
 					for (int i = 0; i < msg.getString("PSS").split(";").length; i++)
 						pss.add(Data.identifyPSSbyname(msg.getString("PSS").split(";")[i]));
 					LOGGER.log(Level.INFO, "PSSID's:" + pss.toString());
-					gs.globalsentiment(null, null, pss);
+					//if(!msg.toString().equals(Settings.top5ReachRequest))
+					gs.globalsentiment(null, null, pss,msg.toString());
 
 				} else
-					gs.globalsentiment(null, null, gr.getTOPReach(5));// computes
-																		// the
-																		// value
-																		// and
-																		// puts
-																		// it in
-																		// the
-																		// DB
-																		// TODO:
-																		// change
-																		// it to
-																		// compute
-																		// only
-																		// if
-																		// not
-																		// computed
-																		// before
+					//if(!msg.toString().equals(Settings.top5ReachRequest))
+					gs.globalsentiment(null, null, gr.getTOPReach(5),msg.toString());
 
-				LOGGER.log(Level.INFO, gs.globalsentiment());
+				LOGGER.log(Level.INFO, gs.globalsentiment(msg.toString()));
 
 				try {
-					result.put(new JSONArray(gs.globalsentiment()));
+					result.put(new JSONArray(gs.globalsentiment(msg.toString())));
 				} catch (JSONException e) {
 					result.put(new JSONObject().put("Graph", "ERROR"));
 				}
+				Settings.top5ReachRequest=msg.toString();
 				return result.toString();
 
 			case 19:

--- a/Diversity/src/general/Data.java
+++ b/Diversity/src/general/Data.java
@@ -196,6 +196,10 @@ public class Data {
 	public static ConcurrentHashMap<Long, DesignProject> getallDp() {
 		return designProjectdb;
 	}
+	
+	public static ConcurrentHashMap<Long, Model> getAllModels() {
+		return modeldb;
+	}
 
 	public static User getUser(long id) {
 		if (userdb.containsKey(id))

--- a/Diversity/src/general/Loader.java
+++ b/Diversity/src/general/Loader.java
@@ -634,6 +634,13 @@ public class Loader {
 	}
 
 	private String loadGeneral() throws JSONException {
+		
+		String delete = "Delete from reach";
+		try (Connection cnlocal = Settings.connlocal(); PreparedStatement query1 = cnlocal.prepareStatement(delete)) {
+			query1.execute();
+		} catch (Exception e) {
+			LOGGER.log(Level.INFO, "ERROR", e);
+		}
 
 		String select = Settings.sqlselectall + " " + Settings.gentable + " WHERE " + Settings.gentable_id + "=1";
 		Connection cnlocal = null;

--- a/Diversity/src/general/Settings.java
+++ b/Diversity/src/general/Settings.java
@@ -344,6 +344,8 @@ public class Settings {
 	public static final String err_unknown = "ERROR ";
 	public static final String err_dbconnect = "Cannot connect to database Please Try Again Later.";
 	public static final String err_cr = "Cannot connect to common repository";
+	
+	public static String top5ReachRequest = null;
 
 	/**
 	 * Conndata.

--- a/Diversity/src/monitoring/Oversight.java
+++ b/Diversity/src/monitoring/Oversight.java
@@ -263,7 +263,7 @@ public class Oversight extends TimerTask {
 		Globalsentiment gs = new Globalsentiment();
 		GetReach gr = new GetReach();
 		try {
-			gs.globalsentiment(null, null, gr.getTOPReach(5));
+			gs.globalsentiment(null, null, gr.getTOPReach(5),"default");
 		} catch (JSONException e) {
 			LOGGER.log(Level.WARNING,"Class:Oversight Error 4");
 		}

--- a/Diversity/src/monitoring/OversightDemo.java
+++ b/Diversity/src/monitoring/OversightDemo.java
@@ -164,7 +164,7 @@ public class OversightDemo extends TimerTask {
 		Globalsentiment gs = new Globalsentiment();
 		GetReach gr = new GetReach();
 		try {
-			gs.globalsentiment(null, null, gr.getTOPReach(5));
+			gs.globalsentiment(null, null, gr.getTOPReach(5),"default");
 		} catch (JSONException e) {
 			LOGGER.log(Level.WARNING, "Class:Oversight Error 4");
 		}


### PR DESCRIPTION
The computation of the pss’s with the most reach (Top5Reach) now doesn’t take into account the column pss on the opinion’s table. Instead it searches for all the pss’s on the existing models and the associated pairs source/account and calculates the average reach of the opinions that correspond to this pair. Also, the computation related to the contruction of the top 5 pss chart in the index page is now made only if the request is different of the previous requests (for that a new column – request VARCHAR(200) -  was added to the table reach). This table is cleared every time oversight runs.